### PR TITLE
feat(dns): 增加 CAA DNS 记录类型支持

### DIFF
--- a/src/api/dns.ts
+++ b/src/api/dns.ts
@@ -1,7 +1,14 @@
 import { useAxios } from '@/utils/requests'
 import { objectToCamelCase, objectToHungarian } from '@/utils/case'
 import { LoadPageFunc, LoadPageResponse, convertPagination } from '@/utils/pagination'
-import { APIResponse, CloudflareErrorResponse, CloudflareDnsRecord, PageSettings, DnsRecordType } from '.'
+import {
+    APIResponse,
+    CloudflareDnsRecordData,
+    CloudflareErrorResponse,
+    CloudflareDnsRecord,
+    PageSettings,
+    DnsRecordType,
+} from '.'
 import type { AxiosError } from 'axios'
 
 
@@ -76,7 +83,7 @@ type CreateDnsRecordRequest = {
     name: string
 
     // DNS record content
-    content: string
+    content?: string
 
     // Time to live for DNS record. Value of 1 is 'automatic'
     ttl: number
@@ -84,6 +91,8 @@ type CreateDnsRecordRequest = {
     // Used with some records like MX and SRV to determine priority.
     // If you do not supply a priority for an MX record, a default value of 0 will be set
     priority?: number
+
+    data?: CloudflareDnsRecordData
 
     // Whether the record is receiving the performance and security benefits of Cloudflare
     proxied?: boolean
@@ -118,6 +127,8 @@ type EditDnsRecordRequest = {
     // Used with some records like MX and SRV to determine priority.
     // If you do not supply a priority for an MX record, a default value of 0 will be set
     priority?: number
+
+    data?: CloudflareDnsRecordData
 
     // Whether the record is receiving the performance and security benefits of Cloudflare
     proxied?: boolean

--- a/src/api/enum.ts
+++ b/src/api/enum.ts
@@ -3,6 +3,7 @@ export enum DnsRecordTypeEnum {
     A = 'A',
     AAAA = 'AAAA',
     CNAME = 'CNAME',
+    CAA = 'CAA',
     TXT = 'TXT',
     SRV = 'SRV',
     LOC = 'LOC',

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -163,7 +163,7 @@ export type PageSettings = {
     page: number
 }
 
-export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'TXT' | 'SRV' | 'LOC' | 'MX'
+export type DnsRecordType = 'A' | 'AAAA' | 'CNAME' | 'CAA' | 'TXT' | 'SRV' | 'LOC' | 'MX'
 | 'NS' | 'SPF' | 'CERT' | 'DNSKEY' | 'DS' | 'NAPTR' | 'SMIMEA' | 'SSHFP'
 | 'TLSA' | 'URI' | DnsRecordTypeEnum
 
@@ -212,10 +212,15 @@ export type CloudflareDnsRecord = {
         [key: string]: string | boolean
     }
     priority?: number
-    data:{
-        weight?: number
-        port?: number
-        target?: string
-        priority?: number
-    }
+    data?: CloudflareDnsRecordData
+}
+
+export type CloudflareDnsRecordData = {
+    weight?: number
+    port?: number
+    target?: string
+    priority?: number
+    flags?: number
+    tag?: string
+    value?: string
 }

--- a/src/route/Login.vue
+++ b/src/route/Login.vue
@@ -68,11 +68,7 @@ const model = reactive({
 const isLoading = ref(false)
 
 const useToken = computed(() => {
-    if (model.token.length === 40) {
-        return true
-    }
-
-    return false
+    return model.token.trim().length > 0
 })
 
 const router = useRouter()

--- a/src/route/zone/record/List.vue
+++ b/src/route/zone/record/List.vue
@@ -272,6 +272,9 @@ function editRecord(record: CloudflareDnsRecord) {
             port: record.data?.port,
             weight: record.data?.weight,
             target: record.data?.target,
+            flags: record.data?.flags ?? 0,
+            tag: record.data?.tag ?? 'issue',
+            value: record.data?.value ?? '',
         },
     })
 

--- a/src/route/zone/record/Record.vue
+++ b/src/route/zone/record/Record.vue
@@ -26,7 +26,7 @@
                     <el-input v-model="model.name" />
                 </el-form-item>
                 <el-form-item
-                    v-if="!isSRV"
+                    v-if="!isSRV && !isCAA"
                     prop="content"
                 >
 
@@ -38,6 +38,52 @@
                         </span>
                     </template>
                     <el-input v-model="model.content" />
+                </el-form-item>
+                <el-form-item
+                    v-if="isCAA"
+                    prop="data.flags"
+                >
+                    <template #label>
+                        <span>
+                            <FontAwesomeIcon icon="flag" /> Flags
+                        </span>
+                    </template>
+                    <el-input-number
+                        v-model="model.data.flags"
+                        :min="0"
+                        :max="255"
+                    />
+                </el-form-item>
+                <el-form-item
+                    v-if="isCAA"
+                    prop="data.tag"
+                >
+                    <template #label>
+                        <span>
+                            <FontAwesomeIcon icon="tag" /> Tag
+                        </span>
+                    </template>
+                    <el-select
+                        v-model="model.data.tag"
+                        allow-create
+                        filterable
+                        placeholder="选择或输入"
+                    >
+                        <el-option label="issue" value="issue" />
+                        <el-option label="issuewild" value="issuewild" />
+                        <el-option label="iodef" value="iodef" />
+                    </el-select>
+                </el-form-item>
+                <el-form-item
+                    v-if="isCAA"
+                    prop="data.value"
+                >
+                    <template #label>
+                        <span>
+                            <FontAwesomeIcon icon="font" /> Value
+                        </span>
+                    </template>
+                    <el-input v-model="model.data.value" />
                 </el-form-item>
                 <el-form-item
                     v-if="requirePriority"
@@ -136,6 +182,7 @@
                     </div>
                 </el-form-item>
                 <el-form-item
+                    v-if="!isCAA"
                     prop="proxied"
                 >
                     <template #label>
@@ -191,20 +238,27 @@ const props = withDefaults(defineProps<{
 
 type RecordModalType = {
     name: string
-    content: string
+    content?: string
     type: DnsRecordType
     ttl: number
     autoTTL?: boolean
     proxied: boolean
     priority?: number
-    data?: SRVRecordModalType
+    data: RecordData
 }
 
-type SRVRecordModalType = {
-    weight: number
-    port: number
-    target: string
+type RecordData = {
+    weight?: number
+    port?: number
+    target?: string
     priority?: number
+    flags?: number
+    tag?: string
+    value?: string
+}
+
+type RecordRequest = Omit<RecordModalType, 'data'> & {
+    data?: RecordData
 }
 
 const DefaultModalValue: RecordModalType = {
@@ -219,7 +273,10 @@ const DefaultModalValue: RecordModalType = {
         weight: 0,
         port: 0,
         target: '',
-        priority: 0
+        priority: 0,
+        flags: 0,
+        tag: 'issue',
+        value: '',
     },
 }
 
@@ -235,6 +292,10 @@ const requirePriority = computed(() => {
 
 const isSRV = computed(() => {
     return model.value.type === 'SRV'
+})
+
+const isCAA = computed(() => {
+    return model.value.type === 'CAA'
 })
 
 const dnsTypes = computed(() => {
@@ -261,7 +322,22 @@ function handleClose() {
 
 const validationRules = reactive<FormRules>({
     name: [{ required: true, message: '请输入记录名称', trigger: 'blur' } ],
-    content: [{ required: true, message: '请输入记录值', trigger: 'blur' } ],
+    content: [{
+        validator: (_rule: unknown, value: unknown, callback: (error?: Error) => void) => {
+            if (isCAA.value || value) {
+                callback()
+            } else {
+                callback(new Error('请输入记录值'))
+            }
+        },
+        trigger: 'blur',
+    }],
+    'data.flags': [
+        { required: true, message: '请输入 CAA Flags', trigger: 'blur' },
+        { type: 'number', min: 0, max: 255, message: 'CAA Flags 需要是 0 到 255 之间的数字', trigger: 'blur' },
+    ],
+    'data.tag': [{ required: true, message: '请输入 CAA Tag', trigger: 'blur' }],
+    'data.value': [{ required: true, message: '请输入 CAA Value', trigger: 'blur' }],
     ttl: [
         { required: true, message: '请输入记录 TTL', trigger: 'blur' },
         { type: 'number', message: 'TTL 需要是一个数字', trigger: 'blur' },
@@ -290,7 +366,7 @@ async function createRecord() {
 
     isLoading.value = true
 
-    const submit = async (doc: RecordModalType) => {
+    const submit = async (doc: RecordRequest) => {
         if (isEditMode.value) {
             if (!record.value) {
                 return
@@ -301,12 +377,15 @@ async function createRecord() {
         }
     }
 
-    const requestBody: RecordModalType = {
+    const requestBody: RecordRequest = {
         name: model.value.name,
-        content: model.value.content,
         type: model.value.type,
         ttl: (model.value.autoTTL) ? 1 : model.value.ttl,
-        proxied: model.value.proxied,
+        proxied: isCAA.value ? false : model.value.proxied,
+    }
+
+    if (!isCAA.value) {
+        requestBody.content = model.value.content
     }
 
     if (requirePriority.value) {
@@ -318,6 +397,13 @@ async function createRecord() {
             weight: model.value.data.weight,
             target: model.value.data.target,
             priority: model.value.priority
+        }
+    }
+    if (isCAA.value) {
+        requestBody.data = {
+            flags: model.value.data.flags ?? 0,
+            tag: model.value.data.tag ?? 'issue',
+            value: model.value.data.value ?? '',
         }
     }
 

--- a/src/utils/icon.ts
+++ b/src/utils/icon.ts
@@ -7,7 +7,9 @@ import {
     faClock,
     faFile,
     faSortNumericUp,
-    faGear
+    faGear,
+    faFlag,
+    faTag,
 } from '@fortawesome/free-solid-svg-icons'
 
 library.add(
@@ -18,4 +20,6 @@ library.add(
     faFile,
     faSortNumericUp,
     faGear,
+    faFlag,
+    faTag,
 )


### PR DESCRIPTION
Add complete CAA DNS record support including:
- add CAA record type to enum and type definitions
- implement CAA-specific form UI with validation rules
- update API types and requests to handle CAA's flags, tag and value fields
- simplify token length check in Login page to accept non-empty trimmed tokens
- add required FontAwesome icons (faFlag, faTag) for CAA form elements